### PR TITLE
add missing libs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,8 @@
 'use strict';
 
-module.exports = exports = require('repl')._builtinLibs;
+module.exports = require('repl')._builtinLibs.concat([
+  'console',
+  'constants',
+  'module',
+  'timers'
+]);


### PR DESCRIPTION
For some odd reason, these libs are not included in `repl._builtinLibs`.